### PR TITLE
Use arb numbers from arb precompiles

### DIFF
--- a/contracts/GeneratorRegistry.sol
+++ b/contracts/GeneratorRegistry.sol
@@ -222,7 +222,7 @@ contract GeneratorRegistry is
         generator.intendedComputeUtilization = newUtilization;
 
         // block number after which this intent which execute
-        reduceComputeRequestBlock[_generatorAddress] = block.number + REDUCTION_REQUEST_BLOCK_GAP;
+        reduceComputeRequestBlock[_generatorAddress] = HELPER.blockNumber() + REDUCTION_REQUEST_BLOCK_GAP;
         emit RequestComputeDecrease(_generatorAddress, newUtilization);
     }
 
@@ -256,7 +256,7 @@ contract GeneratorRegistry is
         generator.declaredCompute = newTotalCompute;
         generator.intendedComputeUtilization = EXPONENT;
 
-        if (!(block.number >= reduceComputeRequestBlock[generatorAddress] && reduceComputeRequestBlock[generatorAddress] != 0)) {
+        if (!(HELPER.blockNumber() >= reduceComputeRequestBlock[generatorAddress] && reduceComputeRequestBlock[generatorAddress] != 0)) {
             revert Error.ReductionRequestNotValid();
         }
 

--- a/contracts/ProofMarketplace.sol
+++ b/contracts/ProofMarketplace.sol
@@ -223,7 +223,7 @@ contract ProofMarketplace is
                 _verifier,
                 _proverPcrs.GET_IMAGE_ID_FROM_PCRS(),
                 _penalty,
-                block.number + MARKET_ACTIVATION_DELAY,
+                HELPER.blockNumber() + MARKET_ACTIVATION_DELAY,
                 _ivsPcrs.GET_IMAGE_ID_FROM_PCRS(),
                 _msgSender,
                 _marketmetadata
@@ -353,7 +353,7 @@ contract ProofMarketplace is
         if (ask.reward == 0 || ask.proverData.length == 0) {
             revert Error.CannotBeZero();
         }
-        if (ask.expiry <= block.number + minProvingTime[secretType]) {
+        if (ask.expiry <= HELPER.blockNumber() + minProvingTime[secretType]) {
             revert Error.CannotAssignExpiredTasks();
         }
 
@@ -363,7 +363,7 @@ contract ProofMarketplace is
         }
 
         Market memory market = marketData[ask.marketId];
-        if (block.number < market.activationBlock) {
+        if (HELPER.blockNumber() < market.activationBlock) {
             revert Error.InactiveMarket();
         }
 
@@ -441,7 +441,7 @@ contract ProofMarketplace is
 
         // time before which matching engine should assign the task to generator
         if (askWithState.state == AskState.CREATE) {
-            if (askWithState.ask.expiry > block.number) {
+            if (askWithState.ask.expiry > HELPER.blockNumber()) {
                 return askWithState.state;
             }
 
@@ -450,7 +450,7 @@ contract ProofMarketplace is
 
         // time before which generator should submit the proof
         if (askWithState.state == AskState.ASSIGNED) {
-            if (askWithState.ask.deadline < block.number) {
+            if (askWithState.ask.deadline < HELPER.blockNumber()) {
                 return AskState.DEADLINE_CROSSED;
             }
 
@@ -517,7 +517,7 @@ contract ProofMarketplace is
         }
 
         askWithState.state = AskState.ASSIGNED;
-        askWithState.ask.deadline = block.number + askWithState.ask.timeTakenForProofGeneration;
+        askWithState.ask.deadline = HELPER.blockNumber() + askWithState.ask.timeTakenForProofGeneration;
         askWithState.generator = generator;
 
         GENERATOR_REGISTRY.assignGeneratorTask(askId, generator, askWithState.ask.marketId);

--- a/contracts/lib/Helper.sol
+++ b/contracts/lib/Helper.sol
@@ -100,4 +100,17 @@ library HELPER {
     bytes32 internal constant NO_ENCLAVE_ID = 0xcd2e66bf0b91eeedc6c648ae9335a78d7c9a4ab0ef33612a824d91cdc68a4f21;
 
     uint256 internal constant ACCEPTABLE_ATTESTATION_DELAY = 60000; // 60 seconds, 60,000 milliseconds
+    
+    function blockNumber() internal view returns (uint256) {
+        return ArbSys(address(100)).arbBlockNumber();
+        // return block.number;
+    }
+}
+
+interface ArbSys {
+    /**
+     * @notice Get Arbitrum block number (distinct from L1 block number; Arbitrum genesis block has block number 0)
+     * @return block number as int
+     */
+    function arbBlockNumber() external view returns (uint256);
 }


### PR DESCRIPTION
Instead of using l1-block-number, proof market place and generator registry now use arbitrum-l2-block-number. 